### PR TITLE
Refine typings across project

### DIFF
--- a/cache-server.ts
+++ b/cache-server.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import type { Server } from "bun";
+
 interface Host {
   ip: string;
   port: number;
@@ -111,7 +113,7 @@ function cleanupOldEntries() {
   removeExpired(caches, CONFIG.CACHE_EXPIRY_SECONDS);
 }
 
-function validateAndAdd<T>({
+function validateAndAdd<T extends { addedAt: number }>({
   item,
   collection,
   validator,
@@ -131,14 +133,14 @@ function validateAndAdd<T>({
 
   const existingIndex = finder(collection);
   if (existingIndex !== -1) {
-    (collection[existingIndex] as any).addedAt = Date.now();
+    collection[existingIndex].addedAt = Date.now();
     return `OK|${updateMessage}`;
   }
 
   collection.push(item);
 
   if (collection.length > maxSize) {
-    collection.sort((a: any, b: any) => a.addedAt - b.addedAt);
+    collection.sort((a, b) => a.addedAt - b.addedAt);
     collection.shift();
   }
 
@@ -256,7 +258,7 @@ function formatSpec2Response(params: URLSearchParams, network: string): string {
   return lines.join("\n");
 }
 
-let server: any;
+let server: Server;
 
 export function startServer() {
   server = Bun.serve({

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,10 @@
+import { QRPManager } from "./qrp_manager";
+import { PeerStore } from "./peer_store";
+
+export interface NodeContext {
+  localIp: string;
+  localPort: number;
+  qrpManager: QRPManager;
+  peerStore: PeerStore;
+  serventId: Buffer;
+}

--- a/src/core_types.ts
+++ b/src/core_types.ts
@@ -68,7 +68,7 @@ export interface QueryHitsMessage extends BaseMessage {
   port: number;
   ipAddress: string;
   speed: number;
-  results: any[];
+  results: FakeFile[];
   vendorCode: Buffer;
   serventId: Buffer;
 }
@@ -99,7 +99,7 @@ export type Message =
 
 export interface Connection {
   id: string;
-  socket: any;
+  socket: import("net").Socket;
   send: (data: Buffer) => void;
   handshake: boolean;
   compressed: boolean;

--- a/src/gnutella_node.ts
+++ b/src/gnutella_node.ts
@@ -3,12 +3,13 @@ import { GnutellaServer } from "./gnutella_server";
 import { PeerStore } from "./peer_store";
 import { QRPManager } from "./qrp_manager";
 import { IDGenerator } from "./id_generator";
+import { NodeContext } from "./context";
 
 export class GnutellaNode {
   private server: GnutellaServer | null = null;
   private peerStore: PeerStore;
   private qrpManager: QRPManager;
-  private context: any;
+  private context: NodeContext | null = null;
 
   constructor() {
     this.peerStore = new PeerStore();

--- a/src/peer_store.ts
+++ b/src/peer_store.ts
@@ -25,7 +25,7 @@ export class PeerStore {
     try {
       const { readFile, writeFile } = await import("fs/promises");
 
-      let existingData: any = {};
+      let existingData: Record<string, unknown> = {};
       try {
         const content = await readFile(this.filename, "utf8");
         existingData = JSON.parse(content);

--- a/src/socket_handler.ts
+++ b/src/socket_handler.ts
@@ -1,18 +1,20 @@
 import { Message } from "./core_types";
 import { MessageParser } from "./message_parser";
+import type { Socket } from "net";
+import type { Inflate, Deflate } from "zlib";
 
 export class SocketHandler {
-  private socket: any;
+  private socket: Socket;
   private buffer: Buffer;
-  private inflater: any;
-  private deflater: any;
+  private inflater?: Inflate;
+  private deflater?: Deflate;
   private compressionEnabled: boolean;
   private onMessage: (msg: Message) => void;
   private onError: (err: Error) => void;
   private onClose: () => void;
 
   constructor(
-    socket: any,
+    socket: Socket,
     onMessage: (msg: Message) => void,
     onError: (err: Error) => void,
     onClose: () => void,
@@ -65,12 +67,12 @@ export class SocketHandler {
     const zlib = require("zlib");
 
     this.inflater = zlib.createInflate();
-    this.inflater.on("data", (chunk: Buffer) => this.handleData(chunk));
-    this.inflater.on("error", this.onError);
+    this.inflater!.on("data", (chunk: Buffer) => this.handleData(chunk));
+    this.inflater!.on("error", this.onError);
 
     this.deflater = zlib.createDeflate({ flush: zlib.Z_SYNC_FLUSH });
-    this.deflater.on("data", (chunk: Buffer) => this.socket.write(chunk));
-    this.deflater.on("error", this.onError);
+    this.deflater!.on("data", (chunk: Buffer) => this.socket.write(chunk));
+    this.deflater!.on("error", this.onError);
   }
 
   private handleData(chunk: Buffer): void {

--- a/tests/cache-server.test.ts
+++ b/tests/cache-server.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 
 describe("cache.ts", () => {
-  let server: any;
+  let server: Bun.Subprocess;
   const baseUrl = "http://localhost:3211";
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary
- define `NodeContext` interface to avoid `any`
- enforce context typing in message router, server, and node
- specify socket and subprocess types
- constrain generic helpers in `cache-server.ts`
- remove leftover `any` usages

## Testing
- `npm exec tsc --noEmit`
- `bun test` *(fails: expect(received).toContain("LastCache"))*

------
https://chatgpt.com/codex/tasks/task_e_685839e7d66083308e9c3c27de57d0b8