### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/src/binary.test.ts
+++ b/src/binary.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from "bun:test";
+import { Binary } from "./binary";
+
+describe("Binary", () => {
+  test("read/write UInt32LE", () => {
+    const buf = Buffer.alloc(4);
+    Binary.writeUInt32LE(buf, 0x12345678, 0);
+    expect(Binary.readUInt32LE(buf, 0)).toBe(0x12345678);
+  });
+
+  test("ip conversions", () => {
+    const ip = "192.168.1.2";
+    const buf = Binary.ipToBuffer(ip);
+    expect(buf).toEqual(Buffer.from([192, 168, 1, 2]));
+    expect(Binary.bufferToIp(buf, 0)).toBe(ip);
+  });
+});

--- a/src/hash.test.ts
+++ b/src/hash.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "bun:test";
+import { Hash } from "./hash";
+import crypto from "crypto";
+
+function qrpExpected(str: string, bits: number): number {
+  const A_INT = 1327217884;
+  const bytes = new TextEncoder().encode(str.toLowerCase());
+  let xor = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    xor ^= bytes[i] << ((i & 3) * 8);
+  }
+  const prod = BigInt(xor >>> 0) * BigInt(A_INT);
+  const mask = (1n << BigInt(bits)) - 1n;
+  return Number((prod >> BigInt(32 - bits)) & mask) >>> 0;
+}
+
+function base32(buf: Buffer): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  let result = "";
+  let value = 0;
+  let bits = 0;
+
+  for (const byte of buf) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      result += chars[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    result += chars[(value << (5 - bits)) & 31];
+  }
+  return result.padEnd(32, "=");
+}
+
+describe("Hash", () => {
+  test("qrp hashing matches algorithm", () => {
+    const str = "Hello world";
+    expect(Hash.qrp(str, 8)).toBe(qrpExpected(str, 8));
+  });
+
+  test("sha1 returns correct buffer", () => {
+    const expected = crypto.createHash("sha1").update("hello").digest();
+    expect(Hash.sha1("hello")).toEqual(expected);
+  });
+
+  test("sha1ToBase32 converts correctly", () => {
+    const sha = crypto.createHash("sha1").update("hello").digest();
+    expect(Hash.sha1ToBase32(sha)).toBe(base32(sha));
+  });
+
+  test("sha1ToUrn adds prefix", () => {
+    const sha = crypto.createHash("sha1").update("hello").digest();
+    expect(Hash.sha1ToUrn(sha)).toBe(`urn:sha1:${base32(sha)}`);
+  });
+});

--- a/src/id_generator.test.ts
+++ b/src/id_generator.test.ts
@@ -1,0 +1,18 @@
+import { describe, test, expect } from "bun:test";
+import { IDGenerator } from "./id_generator";
+
+describe("IDGenerator", () => {
+  test("generate returns buffer with flags", () => {
+    const id = IDGenerator.generate();
+    expect(id.length).toBe(16);
+    expect(id[8]).toBe(0xff);
+    expect(id[15]).toBe(0x00);
+  });
+
+  test("servent returns deterministic id", () => {
+    const expected = [
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ];
+    expect(Array.from(IDGenerator.servent())).toEqual(expected);
+  });
+});

--- a/src/message_builder.test.ts
+++ b/src/message_builder.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test";
+import { MessageBuilder } from "./message_builder";
+import { MessageParser } from "./message_parser";
+import { IDGenerator } from "./id_generator";
+import { Hash } from "./hash";
+
+describe("MessageBuilder", () => {
+  test("handshake", () => {
+    const buf = MessageBuilder.handshake("GNUTELLA CONNECT/0.6", { Foo: "Bar" });
+    const parsed = MessageParser.parse(buf)!;
+    expect(parsed.type).toBe("handshake_connect");
+    expect((parsed as any).headers.Foo).toBe("Bar");
+  });
+
+  test("ping and pong", () => {
+    const ping = MessageBuilder.ping();
+    const pingMsg = MessageParser.parse(ping)!;
+    expect(pingMsg.type).toBe("ping");
+    const pong = MessageBuilder.pong(pingMsg.header.descriptorId, 1234, "1.2.3.4");
+    const pongMsg = MessageParser.parse(pong)!;
+    expect(pongMsg.type).toBe("pong");
+    expect(pongMsg.port).toBe(1234);
+    expect(pongMsg.ipAddress).toBe("1.2.3.4");
+  });
+
+  test("query hit", () => {
+    const sha = Hash.sha1("data");
+    const buf = MessageBuilder.queryHit(
+      IDGenerator.generate(),
+      1111,
+      "1.1.1.1",
+      [{ filename: "file.txt", size: 1, index: 1, sha1: sha, keywords: ["file"] }],
+      IDGenerator.servent(),
+    );
+    const msg = MessageParser.parse(buf)!;
+    expect(msg.type).toBe("query_hits");
+    expect(msg.numberOfHits).toBe(1);
+    expect(msg.port).toBe(1111);
+  });
+});

--- a/src/message_parser.test.ts
+++ b/src/message_parser.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "bun:test";
+import { MessageParser } from "./message_parser";
+import { MessageBuilder } from "./message_builder";
+import { QRPManager } from "./qrp_manager";
+
+describe("MessageParser", () => {
+  test("parses handshake connect", () => {
+    const buf = MessageBuilder.handshake("GNUTELLA CONNECT/0.6", { Foo: "Bar" });
+    const msg = MessageParser.parse(buf)!;
+    expect(msg.type).toBe("handshake_connect");
+    expect((msg as any).headers.Foo).toBe("Bar");
+    expect(MessageParser.getMessageSize(msg, buf)).toBe(buf.length);
+  });
+
+  test("parses ping", () => {
+    const ping = MessageBuilder.ping();
+    const msg = MessageParser.parse(ping)!;
+    expect(msg.type).toBe("ping");
+    expect(MessageParser.getMessageSize(msg, ping)).toBe(ping.length);
+  });
+
+  test("parses pong", () => {
+    const ping = MessageBuilder.ping();
+    const pong = MessageBuilder.pong(MessageParser.parse(ping)!.header.descriptorId, 1234, "1.2.3.4");
+    const msg = MessageParser.parse(pong)!;
+    expect(msg.type).toBe("pong");
+    expect(msg.port).toBe(1234);
+    expect(MessageParser.getMessageSize(msg, pong)).toBe(pong.length);
+  });
+
+  test("parses route table reset", () => {
+    const buf = new QRPManager(32, 7).buildResetMessage();
+    const msg = MessageParser.parse(buf)!;
+    expect(msg.type).toBe("route_table_update");
+    expect((msg as any).variant).toBe("reset");
+  });
+});

--- a/src/peer_store.test.ts
+++ b/src/peer_store.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { PeerStore } from "./peer_store";
+import { mkdtempSync, rmSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+describe("PeerStore", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "peerstore-"));
+    file = join(dir, "peers.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("add, save and load peers", async () => {
+    const store = new PeerStore(file);
+    store.add("1.2.3.4", 1234, 1);
+    await store.save();
+    const data = JSON.parse(readFileSync(file, "utf8"));
+    expect(data.peers.length).toBe(1);
+
+    const store2 = new PeerStore(file);
+    await store2.load();
+    expect(store2.get(1)[0].ip).toBe("1.2.3.4");
+  });
+
+  test("prunes old peers", () => {
+    const store = new PeerStore(file);
+    const old = Date.now() - 10000;
+    store.add("1.2.3.4", 1234, old);
+    store.prune(1000);
+    expect(store.get(1).length).toBe(0);
+  });
+});

--- a/src/qrp_manager.test.ts
+++ b/src/qrp_manager.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "bun:test";
+import { QRPManager } from "./qrp_manager";
+import { MessageParser } from "./message_parser";
+
+describe("QRPManager", () => {
+  test("add/remove and query", () => {
+    const qrp = new QRPManager(32, 7);
+    const idx = qrp.addFile("music.mp3", 123, ["music", "mp3"]);
+    expect(qrp.getFiles().length).toBe(1);
+    expect(qrp.matchesQuery("music")).toBe(true);
+    expect(qrp.getMatchingFiles("music")[0].index).toBe(idx);
+    expect(qrp.removeFile(idx)).toBe(true);
+    expect(qrp.getFiles().length).toBe(0);
+  });
+
+  test("build reset message", () => {
+    const qrp = new QRPManager(32, 7);
+    const buf = qrp.buildResetMessage();
+    const parsed = MessageParser.parse(buf)!;
+    expect(parsed.type).toBe("route_table_update");
+    expect((parsed as any).variant).toBe("reset");
+  });
+
+  test("build patch message", async () => {
+    const qrp = new QRPManager(32, 7);
+    qrp.addFile("a.txt", 1, ["a"]);
+    const msgs = await qrp.buildPatchMessage();
+    expect(msgs.length).toBeGreaterThan(0);
+    for (const m of msgs) {
+      const parsed = MessageParser.parse(m)!;
+      expect(parsed.type).toBe("route_table_update");
+      expect((parsed as any).variant).toBe("patch");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Binary utilities
- test hash helpers
- test ID generation logic
- test message builders and parsers
- cover peer store and QRP manager functionality

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68583ef34be08330ab90eeb4b4779c3d