### PR TITLE
Randomize servent ID generation

### DIFF
--- a/src/id_generator.test.ts
+++ b/src/id_generator.test.ts
@@ -9,10 +9,16 @@ describe("IDGenerator", () => {
     expect(id[15]).toBe(0x00);
   });
 
-  test("servent returns deterministic id", () => {
-    const expected = [
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-    ];
-    expect(Array.from(IDGenerator.servent())).toEqual(expected);
+  test("servent returns random id with flags", () => {
+    const id1 = IDGenerator.servent();
+    const id2 = IDGenerator.servent();
+    expect(id1.length).toBe(16);
+    expect(id1[8]).toBe(0xff);
+    expect(id1[15]).toBe(0x00);
+    expect(id2.length).toBe(16);
+    expect(id2[8]).toBe(0xff);
+    expect(id2[15]).toBe(0x00);
+    // extremely unlikely to be equal if properly random
+    expect(id1.equals(id2)).toBe(false);
   });
 });

--- a/src/id_generator.ts
+++ b/src/id_generator.ts
@@ -8,6 +8,6 @@ export class IDGenerator {
   }
 
   static servent(): Buffer {
-    return Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    return this.generate();
   }
 }


### PR DESCRIPTION
## Summary
- generate a random servent ID instead of using a fixed value
- update tests for the random servent ID

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68584c8f0d5083309b3a734988d7f47c