### PR TITLE
Load library files for sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 failed*
 *.json
+gnutella-library/

--- a/src/core_types.ts
+++ b/src/core_types.ts
@@ -79,7 +79,7 @@ export interface QueryHitsMessage extends BaseMessage {
   port: number;
   ipAddress: string;
   speed: number;
-  results: FakeFile[];
+  results: SharedFile[];
   vendorCode: Buffer;
   serventId: Buffer;
 }
@@ -123,7 +123,7 @@ export interface Peer {
   lastSeen: number;
 }
 
-export interface FakeFile {
+export interface SharedFile {
   filename: string;
   size: number;
   index: number;

--- a/src/gnutella_node.test.ts
+++ b/src/gnutella_node.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { GnutellaNode } from "./gnutella_node";
+
+let origCwd: string;
+let dir: string;
+
+beforeEach(() => {
+  origCwd = process.cwd();
+  dir = mkdtempSync(join(tmpdir(), "gnutella-node-"));
+  process.chdir(dir);
+});
+
+afterEach(() => {
+  process.chdir(origCwd);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("loadSharedFiles", () => {
+  test("creates directory when missing", async () => {
+    const node = new GnutellaNode();
+    await node.loadSharedFiles();
+    expect(existsSync(join(dir, "gnutella-library"))).toBe(true);
+    const files = node.getSharedFiles();
+    expect(files.length).toBe(0);
+  });
+
+  test("loads files from library", async () => {
+    const lib = join(dir, "gnutella-library");
+    mkdirSync(lib, { recursive: true });
+    writeFileSync(join(lib, "song.mp3"), "a");
+    writeFileSync(join(lib, "doc.txt"), "b");
+
+    const node = new GnutellaNode();
+    await node.loadSharedFiles();
+    const filenames = node.getSharedFiles().map((f) => f.filename);
+    expect(filenames.sort()).toEqual(["doc.txt", "song.mp3"]);
+  });
+});

--- a/src/gnutella_server.ts
+++ b/src/gnutella_server.ts
@@ -2,6 +2,7 @@ import { Connection, Message, NodeContext } from "./core_types";
 import { SocketHandler } from "./socket_handler";
 import { MessageRouter } from "./message_router";
 import type { Server as NetServer, Socket } from "net";
+import net from "net";
 
 export class GnutellaServer {
   private server: NetServer | null = null;
@@ -16,8 +17,6 @@ export class GnutellaServer {
   }
 
   async start(port: number): Promise<void> {
-    const net = await import("net");
-
     this.server = net.createServer((socket) => this.handleConnection(socket));
 
     return new Promise((resolve, reject) => {

--- a/src/message_builder.test.ts
+++ b/src/message_builder.test.ts
@@ -10,9 +10,10 @@ describe("MessageBuilder", () => {
     const buf = MessageBuilder.handshake("GNUTELLA CONNECT/0.6", {
       Foo: "Bar",
     });
-    const parsed = MessageParser.parse(buf)!;
+    const parsed =
+      MessageParser.parse(buf) as import("./core_types").HandshakeConnectMessage;
     expect(parsed.type).toBe("handshake_connect");
-    expect((parsed as any).headers.Foo).toBe("Bar");
+    expect(parsed.headers.Foo).toBe("Bar");
   });
 
   test("ping and pong", () => {

--- a/src/message_builder.ts
+++ b/src/message_builder.ts
@@ -2,7 +2,7 @@ import { Protocol, MessageType } from "./constants";
 import { Binary } from "./binary";
 import { IDGenerator } from "./id_generator";
 import { Hash } from "./hash";
-import { FakeFile } from "./core_types";
+import { SharedFile } from "./core_types";
 
 export class MessageBuilder {
   static header(
@@ -63,7 +63,7 @@ export class MessageBuilder {
     queryId: Buffer,
     port: number,
     ip: string,
-    files: FakeFile[],
+    files: SharedFile[],
     serventId: Buffer,
   ): Buffer {
     const fileEntries = files.map((file) => this.fileEntry(file));
@@ -91,7 +91,7 @@ export class MessageBuilder {
     ]);
   }
 
-  private static fileEntry(file: FakeFile): Buffer {
+  private static fileEntry(file: SharedFile): Buffer {
     const nameBuf = Buffer.from(file.filename, "utf8");
     const sha1Urn = file.sha1
       ? Buffer.from(Hash.sha1ToUrn(file.sha1), "utf8")

--- a/src/message_parser.test.ts
+++ b/src/message_parser.test.ts
@@ -9,9 +9,10 @@ describe("MessageParser", () => {
     const buf = MessageBuilder.handshake("GNUTELLA CONNECT/0.6", {
       Foo: "Bar",
     });
-    const msg = MessageParser.parse(buf)!;
+    const msg =
+      MessageParser.parse(buf) as import("./core_types").HandshakeConnectMessage;
     expect(msg.type).toBe("handshake_connect");
-    expect((msg as any).headers.Foo).toBe("Bar");
+    expect(msg.headers.Foo).toBe("Bar");
     expect(MessageParser.getMessageSize(msg, buf)).toBe(buf.length);
   });
 
@@ -38,8 +39,9 @@ describe("MessageParser", () => {
 
   test("parses route table reset", () => {
     const buf = new QRPManager(32, 7).buildResetMessage();
-    const msg = MessageParser.parse(buf)!;
+    const msg =
+      MessageParser.parse(buf) as import("./core_types").RouteTableUpdateMessage;
     expect(msg.type).toBe("route_table_update");
-    expect((msg as any).variant).toBe("reset");
+    expect(msg.variant).toBe("reset");
   });
 });

--- a/src/peer_store.ts
+++ b/src/peer_store.ts
@@ -1,4 +1,5 @@
 import { Peer } from "./core_types";
+import { readFile, writeFile } from "fs/promises";
 
 export class PeerStore {
   private peers: Map<string, Peer>;
@@ -11,7 +12,6 @@ export class PeerStore {
 
   async load(): Promise<void> {
     try {
-      const { readFile } = await import("fs/promises");
       const data = await readFile(this.filename, "utf8");
       const parsed = JSON.parse(data);
 
@@ -23,8 +23,6 @@ export class PeerStore {
 
   async save(): Promise<void> {
     try {
-      const { readFile, writeFile } = await import("fs/promises");
-
       let existingData: Record<string, unknown> = {};
       try {
         const content = await readFile(this.filename, "utf8");

--- a/src/qrp_manager.test.ts
+++ b/src/qrp_manager.test.ts
@@ -16,9 +16,10 @@ describe("QRPManager", () => {
   test("build reset message", () => {
     const qrp = new QRPManager(32, 7);
     const buf = qrp.buildResetMessage();
-    const parsed = MessageParser.parse(buf)!;
+    const parsed =
+      MessageParser.parse(buf) as import("./core_types").RouteTableUpdateMessage;
     expect(parsed.type).toBe("route_table_update");
-    expect((parsed as any).variant).toBe("reset");
+    expect(parsed.variant).toBe("reset");
   });
 
   test("build patch message", async () => {
@@ -27,9 +28,10 @@ describe("QRPManager", () => {
     const msgs = await qrp.buildPatchMessage();
     expect(msgs.length).toBeGreaterThan(0);
     for (const m of msgs) {
-      const parsed = MessageParser.parse(m)!;
+      const parsed =
+        MessageParser.parse(m) as import("./core_types").RouteTableUpdateMessage;
       expect(parsed.type).toBe("route_table_update");
-      expect((parsed as any).variant).toBe("patch");
+      expect(parsed.variant).toBe("patch");
     }
   });
 });


### PR DESCRIPTION
## Summary
- rename `FakeFile` to `SharedFile` and update QRP table manager
- rename `setupFakeFiles` to `loadSharedFiles` and drop dynamic imports
- switch remaining dynamic imports to static imports
- update tests for new behaviour
- remove any casts and expose shared files via `getSharedFiles`

## Testing
- `bun x tsc -p tsconfig.json`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_685853f6b33083308543270928334382